### PR TITLE
patching twoQubit and multiQubit unitaries

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -1382,7 +1382,19 @@ int measure(Qureg qureg, int measureQubit);
  */
 int measureWithStats(Qureg qureg, int measureQubit, qreal *outcomeProb);
 
-/** Computes <bra|ket> */
+/** Computes the inner product \f$ \langle \text{bra} | \text{ket} \rangle \f$ of two 
+ * equal-size state vectors. The same \p qureg may be passed as both \p bra and \p ket, 
+ * though we recommend users check state-vector normalisation with \p calcTotalProb which 
+ * employs Kahan summation for greater accuracy.
+ * Neither state-vector is modified.
+ *
+ * @param[in] bra qureg to be the 'bra' (i.e. have its values conjugate transposed) in the inner product 
+ * @param[in] ket qureg to be the 'ket' in the inner product 
+ * @return the complex inner product of \p bra and \p ket 
+ * @throws exitWithError
+ *      if either \p bra or \p ket are not state-vectors, 
+ *      or if \p bra and \p ket do not have equal dimensions.
+ */
 Complex calcInnerProduct(Qureg bra, Qureg ket);
 
 /** Seed the Mersenne Twister used for random number generation in the QuEST environment with an example

--- a/QuEST/src/CPU/QuEST_cpu_internal.h
+++ b/QuEST/src/CPU/QuEST_cpu_internal.h
@@ -42,6 +42,12 @@ inline long long int insertZeroBit(long long int number, int index) {
     return (left << 1) ^ right;
 }
 
+inline long long int insertTwoZeroBits(long long int number, int bit1, int bit2) {
+    int small = (bit1 < bit2)? bit1 : bit2;
+    int big = (bit1 < bit2)? bit2 : bit1;
+    return insertZeroBit(insertZeroBit(number, small), big);
+}
+
 
 /*
  * density matrix operations


### PR DESCRIPTION
controlled two-qubit unitaries were wrong, as were two-qubit and multi-qubit unitaries with non-strictly-increasing target qubits